### PR TITLE
Prevent float divide by zero that could create NaN progress values.

### DIFF
--- a/main/src/aquarion/world/type/AquaGenericCrafter.java
+++ b/main/src/aquarion/world/type/AquaGenericCrafter.java
@@ -39,6 +39,7 @@ import mindustry.world.draw.DrawBlock;
 import mindustry.world.draw.DrawDefault;
 import mindustry.world.meta.*;
 
+import static java.lang.Float.NaN;
 import static mindustry.Vars.tilesize;
 import static mindustry.Vars.world;
 
@@ -435,7 +436,8 @@ public class AquaGenericCrafter extends aquarion.world.type.AquaBlock {
             if(outputLiquids != null){
                 max = 0f;
                 for(LiquidStack s : outputLiquids){
-                    float value = (liquidCapacity - liquids.get(s.liquid)) / (s.amount * edelta());
+                    float maxOutput = (s.amount * edelta());
+                    float value = (maxOutput > 0)?(liquidCapacity - liquids.get(s.liquid)) / (maxOutput): 0;
                     scaling = Math.min(scaling, value);
                     max = Math.max(max, value);
                 }


### PR DESCRIPTION
Checking for divide by zero in AquaGenericCrafterBuild.getProgressIncrease() to prevent the introduction of NaN progress timers.