### PR TITLE
Fix icons

### DIFF
--- a/tools/src/aquarion/tools/GenAtlas.java
+++ b/tools/src/aquarion/tools/GenAtlas.java
@@ -1,6 +1,7 @@
 package aquarion.tools;
 
 import arc.files.Fi;
+import arc.graphics.Color;
 import arc.graphics.Pixmap;
 import arc.graphics.Pixmaps;
 import arc.graphics.Texture;
@@ -144,7 +145,11 @@ public class GenAtlas extends TextureAtlas{
          * @see Pixmap#dispose()
          */
         public Pixmap pixmap(){
-            if(!found()) throw new IllegalArgumentException("Region does not exist: " + name);
+            if(!found()){
+                Pixmap pixmap = new Pixmap(64, 64);
+                pixmap.fill(Color.magenta);
+                return pixmap;
+            }
             return pixmap;
         }
 

--- a/tools/src/aquarion/tools/GenAtlas.java
+++ b/tools/src/aquarion/tools/GenAtlas.java
@@ -1,13 +1,11 @@
 package aquarion.tools;
 
 import arc.files.Fi;
-import arc.graphics.Color;
-import arc.graphics.Pixmap;
-import arc.graphics.Pixmaps;
-import arc.graphics.Texture;
+import arc.graphics.*;
 import arc.graphics.g2d.PixmapRegion;
 import arc.graphics.g2d.TextureAtlas;
 import arc.graphics.g2d.TextureRegion;
+import arc.graphics.gl.PixmapTextureData;
 import arc.struct.ObjectMap;
 
 import static aquarion.tools.Tools.atlas;
@@ -125,9 +123,13 @@ public class GenAtlas extends TextureAtlas{
             this.name = name;
             this.pixmap = pixmap;
 
+            //added to allow methods like TextureRegion.split() to function without error
+            this.texture = Texture.createEmpty(new PixmapTextureData(pixmap, false, false));
             if(pixmap != null){
                 width = pixmap.width;
                 height = pixmap.height;
+                this.texture.width = width;
+                this.texture.height = height;
             }
 
             u = v = 0f;

--- a/tools/src/aquarion/tools/Processors.java
+++ b/tools/src/aquarion/tools/Processors.java
@@ -17,7 +17,7 @@ public final class Processors{
 //            new OutlineRegionProcessor(),
             new UnitProcessor(),
             new ItemProcessor(),
-//            new BlockProcessor()
+            new BlockProcessor()
     };
 
     private Processors(){

--- a/tools/src/aquarion/tools/proc/BlockProcessor.java
+++ b/tools/src/aquarion/tools/proc/BlockProcessor.java
@@ -115,8 +115,16 @@ public class BlockProcessor implements Processor{
                         }
                     }
                 }
-
                 TextureRegion[] regions = block.getGeneratedIcons();
+                if(regions == null){
+                    regions = new TextureRegion[]{};
+                }
+                for(int i = 0; i < regions.length; i++){
+                    if(regions[i] == null){
+                        //name doesn't matter unless you decide you want to add a missing texture for this.
+                        regions[i] = atlas.find("missing");
+                    }
+                }
                 if(regions.length == 0){
                     if(shardTeamTop != null) shardTeamTop.dispose();
                     return;
@@ -173,10 +181,16 @@ public class BlockProcessor implements Processor{
 
                 if(image != null){
                     String uiIconName = block.name + "-ui";
+                    Log.debug("generating block icon " + block.name);
                     if(!atlas.has(uiIconName)){
-                        GenRegion uiRegion = new GenRegion(uiIconName, image);
+                        int size = Math.min(image.width, 128);
+                        Pixmap scaled = new Pixmap(size, size);
+                        //TODO bad linear scaling
+                        scaled.draw(image, 0, 0, image.width, image.height, 0, 0, size, size, true, true);
+                        GenRegion uiRegion = new GenRegion(uiIconName, scaled);
                         uiRegion.relativePath = "ui";
                         uiRegion.save(true);
+                        Log.debug("generated block icon " + block.name);
                     }else{
                         image.dispose();
                     }


### PR DESCRIPTION
Scale down large textures when generating icons to save atlas space
Prevent icon layers returning null from breaking icon generation
Add dummy texture to prevent errors when blocks and drawers require them on load