### PR TITLE
Fixed liquid filter bars displaying liquids the filter does not contain/is not consuming.

### DIFF
--- a/main/assets/bundles/bundle.properties
+++ b/main/assets/bundles/bundle.properties
@@ -785,6 +785,8 @@ stat.outputmultiplier = [stat]{0}% Item Output Multiplier
 
 ##BARS
 bar.boost =  Boost
+bar.boost.empty = No Boost
+bar.boost.liquid = {0} Boost
 
 
 ##THREAT LEVELS

--- a/main/src/aquarion/ui/AquaBarHelpers.java
+++ b/main/src/aquarion/ui/AquaBarHelpers.java
@@ -1,0 +1,45 @@
+package aquarion.ui;
+
+import arc.Core;
+import arc.func.Func;
+import arc.graphics.Color;
+import mindustry.gen.Building;
+import mindustry.type.Liquid;
+import mindustry.ui.Bar;
+
+public class AquaBarHelpers {
+    public interface CustomBarHolder{
+
+        <T extends Building> void addBar(String name, Func<T, Bar> sup);
+
+        default void addLiquidBoostBar(Liquid liq){
+            addBar("liquid-" + liq.name + Core.bundle.get("bar.boost"), entity -> !liq.unlockedNow() ? null : new Bar(
+                    () -> Core.bundle.format("bar.boost.liquid", liq.localizedName),
+                    liq::barColor,
+                    () -> entity.liquids.get(liq) / entity.block.liquidCapacity
+            ));
+        }
+
+        default <T extends Building> void addLiquidBoostBar(Func<T, Liquid> current){
+            this.<T>addBar("liquid", entity -> {
+                return new Bar(
+                        () -> {
+                            Liquid liq = current.get(entity);
+                            if(liq != null && !liq.unlockedNow()) liq = null;
+                            return (liq == null || entity.liquids.get(liq) <= 0.001f ? Core.bundle.get("bar.boost.empty") : Core.bundle.format("bar.boost.liquid", liq.localizedName));
+                            },
+                        () -> {
+                            Liquid liq = current.get(entity);
+                            if(liq != null && !liq.unlockedNow()) liq = null;
+                            return liq == null ? Color.clear : liq.barColor();
+                            },
+                        () -> {
+                            Liquid liq = current.get(entity);
+                            if(liq != null && !liq.unlockedNow()) liq = null;
+                            return liq == null ? 0f : entity.liquids.get(liq) / entity.block.liquidCapacity;
+                        }
+                );
+            });
+        }
+    }
+}

--- a/main/src/aquarion/world/blocks/production/ModifiedbeamDrill.java
+++ b/main/src/aquarion/world/blocks/production/ModifiedbeamDrill.java
@@ -1,5 +1,6 @@
 package aquarion.world.blocks.production;
 
+import aquarion.ui.AquaBarHelpers;
 import aquarion.world.Uti.AquaStats;
 import arc.Core;
 import arc.graphics.Blending;
@@ -12,30 +13,25 @@ import arc.math.Mathf;
 import arc.math.geom.Geometry;
 import arc.math.geom.Point2;
 import arc.struct.Seq;
-import arc.util.Eachable;
-import arc.util.Nullable;
-import arc.util.Time;
-import arc.util.Tmp;
+import arc.util.*;
 import mindustry.entities.units.BuildPlan;
 import mindustry.graphics.Drawf;
 import mindustry.graphics.Layer;
 import mindustry.type.Item;
+import mindustry.type.LiquidStack;
 import mindustry.world.Tile;
 import mindustry.world.blocks.environment.Floor;
 import mindustry.world.blocks.environment.StaticWall;
 import mindustry.world.blocks.environment.TallBlock;
 import mindustry.world.blocks.production.BeamDrill;
-import mindustry.world.consumers.Consume;
-import mindustry.world.consumers.ConsumeItems;
-import mindustry.world.consumers.ConsumeLiquid;
-import mindustry.world.consumers.ConsumeLiquidBase;
+import mindustry.world.consumers.*;
 import mindustry.world.meta.Stat;
 import mindustry.world.meta.StatUnit;
 import mindustry.world.meta.StatValues;
 
 import static mindustry.Vars.tilesize;
 
-public class ModifiedbeamDrill extends BeamDrill {
+public class ModifiedbeamDrill extends BeamDrill implements AquaBarHelpers.CustomBarHolder {
     public TextureRegion top1, top2;
     public @Nullable Item blockedItem;
     /** Special exemption items that this drill can't mine. */
@@ -81,6 +77,38 @@ public class ModifiedbeamDrill extends BeamDrill {
             );
         }
     }
+
+    @Override
+    public void setBars(){
+        super.setBars();
+
+        for(Consume consl : consumers){
+            if(consl instanceof ConsumeLiquid liq){
+                removeBar("liquid-" + liq.liquid.name);
+                if(consl.booster){
+                    addLiquidBoostBar(liq.liquid);
+                } else {
+                    addLiquidBar(liq.liquid);
+                }
+            }else if(consl instanceof ConsumeLiquids multi){
+                for(LiquidStack stack : multi.liquids){
+                    removeBar("liquid-" + stack.liquid.name);
+                    if(consl.booster){
+                        addLiquidBoostBar(stack.liquid);
+                    }else {
+                        addLiquidBar(stack.liquid);
+                    }
+                }
+            }else if(consl instanceof ConsumeLiquidFilter filt){
+                if(consl.booster){
+                    addLiquidBoostBar(filt::getConsumed);
+                }else {
+                    addLiquidBar(filt::getConsumed);
+                }
+            }
+        }
+    }
+
     public ModifiedbeamDrill(String name) {
         super(name);
     }

--- a/main/src/aquarion/world/blocks/turrets/AquaItemTurret.java
+++ b/main/src/aquarion/world/blocks/turrets/AquaItemTurret.java
@@ -1,11 +1,16 @@
 package aquarion.world.blocks.turrets;
 
+import aquarion.ui.AquaBarHelpers;
 import aquarion.world.Uti.AquaStatValues;
-import mindustry.entities.part.DrawPart;
+import mindustry.type.LiquidStack;
 import mindustry.world.blocks.defense.turrets.ItemTurret;
+import mindustry.world.consumers.Consume;
+import mindustry.world.consumers.ConsumeLiquid;
+import mindustry.world.consumers.ConsumeLiquidFilter;
+import mindustry.world.consumers.ConsumeLiquids;
 import mindustry.world.meta.Stat;
 
-public class AquaItemTurret extends ItemTurret {
+public class AquaItemTurret extends ItemTurret implements AquaBarHelpers.CustomBarHolder {
     public AquaItemTurret(String name) {
         super(name);
     }
@@ -14,5 +19,36 @@ public class AquaItemTurret extends ItemTurret {
         super.setStats();
         stats.remove(Stat.ammo);
         stats.add(Stat.ammo, AquaStatValues.ammo(ammoTypes));
+    }
+
+    @Override
+    public void setBars(){
+        super.setBars();
+
+        for(Consume consl : consumers){
+            if(consl instanceof ConsumeLiquid liq){
+                removeBar("liquid-" + liq.liquid.name);
+                if(consl.booster){
+                    addLiquidBoostBar(liq.liquid);
+                } else {
+                    addLiquidBar(liq.liquid);
+                }
+            }else if(consl instanceof ConsumeLiquids multi){
+                for(LiquidStack stack : multi.liquids){
+                    removeBar("liquid-" + stack.liquid.name);
+                    if(consl.booster){
+                        addLiquidBoostBar(stack.liquid);
+                    }else {
+                        addLiquidBar(stack.liquid);
+                    }
+                }
+            }else if(consl instanceof ConsumeLiquidFilter filt){
+                if(consl.booster){
+                    addLiquidBoostBar(filt::getConsumed);
+                }else {
+                    addLiquidBar(filt::getConsumed);
+                }
+            }
+        }
     }
 }

--- a/main/src/aquarion/world/type/AquaBlock.java
+++ b/main/src/aquarion/world/type/AquaBlock.java
@@ -1,5 +1,6 @@
 package aquarion.world.type;
 
+import aquarion.ui.AquaBarHelpers;
 import arc.graphics.g2d.Draw;
 import arc.math.Mathf;
 import mindustry.world.Block;
@@ -7,7 +8,7 @@ import mindustry.world.Tile;
 
 import static aquarion.world.graphics.Renderer.Layer.shadow;
 
-public class AquaBlock extends Block {
+public class AquaBlock extends Block implements AquaBarHelpers.CustomBarHolder {
     public AquaBlock(String name) {
         super(name);
     }

--- a/main/src/aquarion/world/type/AquaGenericCrafter.java
+++ b/main/src/aquarion/world/type/AquaGenericCrafter.java
@@ -9,17 +9,13 @@ import arc.math.Mathf;
 import arc.math.geom.Geometry;
 import arc.struct.EnumSet;
 import arc.struct.Seq;
-import arc.util.Eachable;
-import arc.util.Nullable;
-import arc.util.Time;
-import arc.util.Tmp;
+import arc.util.*;
 import arc.util.io.Reads;
 import arc.util.io.Writes;
 import mindustry.Vars;
 import mindustry.content.Fx;
 import mindustry.entities.Damage;
 import mindustry.entities.Effect;
-import mindustry.entities.Puddles;
 import mindustry.entities.units.BuildPlan;
 import mindustry.gen.Building;
 import mindustry.gen.Sounds;
@@ -39,7 +35,6 @@ import mindustry.world.draw.DrawBlock;
 import mindustry.world.draw.DrawDefault;
 import mindustry.world.meta.*;
 
-import static java.lang.Float.NaN;
 import static mindustry.Vars.tilesize;
 import static mindustry.Vars.world;
 
@@ -153,13 +148,7 @@ public class AquaGenericCrafter extends aquarion.world.type.AquaBlock {
             }
         }
     }
-    public void addLiquidBoostBar(Liquid liq){
-        addBar("liquid-" + liq.name + Core.bundle.get("bar.boost"), entity -> !liq.unlockedNow() ? null : new Bar(
-                () -> liq.localizedName + " " + Core.bundle.get("bar.boost"),
-                liq::barColor,
-                () -> entity.liquids.get(liq) / liquidCapacity
-        ));
-    }
+
     @Override
     public void setBars(){
         super.setBars();
@@ -193,7 +182,11 @@ public class AquaGenericCrafter extends aquarion.world.type.AquaBlock {
                 }
             }else if(consl instanceof ConsumeLiquidFilter filt){
                 added = true;
-                addLiquidBar(build -> build.liquids.current());
+                if(consl.booster){
+                    addLiquidBoostBar(filt::getConsumed);
+                }else {
+                    addLiquidBar(filt::getConsumed);
+                }
             }
         }
         if(hasHeat && (heatRequirement > 0 || heatRequirement < 0)){


### PR DESCRIPTION
Replaced liquid filter consumer's vanilla-style multi-liquid bar with a bar that switches liquids according to what the consumer wants to consume.

Added some bundle text for the new bar, and refactored an old one. (I used a format string to add the liquid rather than string concatenation to all bundles to choose where the liquid name should be in the bundle text.)