### PR TITLE
Set research tree to dynamically select radii

### DIFF
--- a/main/assets/bundles/bundle.properties
+++ b/main/assets/bundles/bundle.properties
@@ -620,6 +620,7 @@ settings.betterfine = The better fine.ogg (needs restart)
 settings.richPrescense = Discord Rich Presence
 settings.resethints = Reset Hints
 settings.onlyModMus = Remove vanilla music (needs restart)
+settings.debugResearchRendering = [Debug Render] Research Tree Borders
 settings.clearTech-category = Clear Research. (Aquarion only)
 settings.clearTech-confirm = [scarlet]Are you doubly sure?[]
 settings.clearCampaign = Clear Campaign saves. (Aquarion only)

--- a/main/src/aquarion/dialogs/AquaResearchDialog.java
+++ b/main/src/aquarion/dialogs/AquaResearchDialog.java
@@ -2,6 +2,7 @@ package aquarion.dialogs;
 
 import aquarion.ModEventHandler;
 import aquarion.content.AquaPlanets;
+import aquarion.ui.ModSettings;
 import arc.Core;
 import arc.Events;
 import arc.graphics.Color;
@@ -12,6 +13,7 @@ import arc.math.Angles;
 import arc.math.Interp;
 import arc.math.Mathf;
 import arc.math.geom.Rect;
+import arc.math.geom.Vec2;
 import arc.scene.Element;
 import arc.scene.Group;
 import arc.scene.actions.Actions;
@@ -26,9 +28,7 @@ import arc.scene.ui.Label;
 import arc.scene.ui.TextButton.TextButtonStyle;
 import arc.scene.ui.layout.Scl;
 import arc.scene.ui.layout.Table;
-import arc.struct.ObjectMap;
-import arc.struct.ObjectSet;
-import arc.struct.Seq;
+import arc.struct.*;
 import arc.util.*;
 import mindustry.Vars;
 import mindustry.content.Planets;
@@ -65,6 +65,9 @@ public class AquaResearchDialog extends BaseDialog {
     public Rect bounds = new Rect();
     public ItemsDisplay itemDisplay;
     public View view;
+
+    //The spacings between depth layers. Used to align layers.
+    public IntFloatMap spacings = new IntFloatMap();
 
     public ItemSeq items;
 
@@ -316,8 +319,12 @@ public class AquaResearchDialog extends BaseDialog {
         return sum;
     }
 
-    void layoutRadialSmart(TechTreeNode node, float startAngle, float endAngle, int depth, float spacing){
-        float radius = spacing * depth;
+    void layoutRadialSmart(TechTreeNode node, float startAngle, float endAngle, int depth){
+        final float minimumNodeRadius = Mathf.dst(nodeSize,nodeSize) * 2f;
+
+        node.leftBorderPos.set(1,0).rotate(startAngle).nor();
+        node.rightBorderPos.set(1,0).rotate(endAngle).nor();
+        node.depth = depth - 1;
         if(node.children.length == 0) return;
 
         int nodeCount = node.children.length;
@@ -332,6 +339,27 @@ public class AquaResearchDialog extends BaseDialog {
 
         float angleCursor = startAngle;
 
+        //find the smallest gap between members in this group of nodes. That angle will determine the radius.
+        float smallest = 360;
+        for(int i = 0; i < node.children.length; i++) {
+            int j = Mathf.mod(i - 1, node.children.length);
+            float angleWidth = (endAngle - startAngle) * (weights[i] / totalWeight) / 2 + (endAngle - startAngle) * (weights[j] / totalWeight) / 2;
+            if(smallest > angleWidth){
+                smallest = angleWidth;
+            }
+        }
+
+        //compute the radius
+        float lastRadius = computeRadiusAt(depth - 1);
+        float fitRadius = Math.max(minimumNodeRadius / (2 * Mathf.sinDeg(smallest)), lastRadius + minimumNodeRadius);
+        float spacing = fitRadius - lastRadius;
+        if(spacings.get(depth, 0) < spacing){
+            spacings.put(depth, spacing);
+        } else {
+            fitRadius = lastRadius + Math.max(spacings.get(depth, 0), minimumNodeRadius);
+        }
+
+        //compute node placement angles
         for(int i = 0; i < node.children.length; i++){
             TechTreeNode child = node.children[i];
             float weightRatio = weights[i] / totalWeight;
@@ -339,12 +367,21 @@ public class AquaResearchDialog extends BaseDialog {
             float angle = angleCursor + angleWidth / 2f;
             float rad = angle * Mathf.degreesToRadians;
 
-            child.x = Mathf.cos(rad) * radius;
-            child.y = Mathf.sin(rad) * radius;
+            child.x = Mathf.cos(rad);
+            child.y = Mathf.sin(rad);
 
-            layoutRadialSmart(child, angleCursor, angleCursor + angleWidth, depth + 1, spacing);
+            layoutRadialSmart(child, angleCursor, angleCursor + angleWidth, depth + 1);
 
             angleCursor += angleWidth;
+        }
+
+        //final pass, push nodes up to their chosen radii
+        for(int i = 0; i < node.children.length; i++){
+            TechTreeNode child = node.children[i];
+
+            float radius = computeRadiusAt(child.depth);
+            child.x *= radius;
+            child.y *= radius;
         }
     }
 
@@ -369,7 +406,7 @@ public class AquaResearchDialog extends BaseDialog {
         root.y = 0f;
 
         // Big brain moment here folks
-        layoutRadialSmart(root, 0f, 360f, 1, ringSpacing);
+        layoutRadialSmart(root, 0f, 360f, 1);
 
         // Recalculate bounds
         float minx = 0f, miny = 0f, maxx = 0f, maxy = 0f;
@@ -408,6 +445,13 @@ public class AquaResearchDialog extends BaseDialog {
         public final TechNode node;
         public boolean visible = true, selectable = true;
 
+        //the angle of the leftmost border
+        public Vec2 leftBorderPos;
+
+        //the angle of the rightmost border
+        public Vec2 rightBorderPos;
+        public int depth = 0;
+
         public TechTreeNode(TechNode node, TechTreeNode parent) {
             this.node = node;
             this.parent = parent;
@@ -417,6 +461,8 @@ public class AquaResearchDialog extends BaseDialog {
             for (int i = 0; i < children.length; i++) {
                 children[i] = new TechTreeNode(node.children.get(i), this);
             }
+            leftBorderPos = new Vec2();
+            rightBorderPos = new Vec2();
         }
     }
 
@@ -788,7 +834,7 @@ public class AquaResearchDialog extends BaseDialog {
 
 
             for(int i = 1; i <= maxDepth; i++){
-                float radius = spacing * i;
+                float radius = computeRadiusAt(i);
                 float cx = panX + width / 2f;
                 float cy = panY + height / 2f;
 
@@ -818,6 +864,19 @@ public class AquaResearchDialog extends BaseDialog {
                 Lines.stroke(12f);
                 Lines.dashLine(node.x+offsetX, node.y+offsetY, node.x+cx, node.y+cy, 10);
 
+                if(ModSettings.getDebugResearchRendering()) {
+                    float nodeRadius = computeRadiusAt(node.depth);
+                    float nodeSpacing = spacings.get(node.depth + 1, 0);
+
+                    Draw.color(Color.red);
+                    Tmp.v1.set(node.leftBorderPos).scl(nodeRadius).add(offsetX, offsetY);
+                    Tmp.v2.set(node.leftBorderPos).scl(nodeSpacing).add(Tmp.v1);
+                    Lines.line(Tmp.v1.x, Tmp.v1.y, Tmp.v2.x, Tmp.v2.y);
+
+                    Tmp.v1.set(node.rightBorderPos).scl(nodeRadius).add(offsetX, offsetY);
+                    Tmp.v2.set(node.rightBorderPos).scl(nodeSpacing).add(Tmp.v1);
+                    Lines.line(Tmp.v1.x, Tmp.v1.y, Tmp.v2.x, Tmp.v2.y);
+                }
 
                 for (TechTreeNode child : node.children) {
                     if (!child.visible) continue;
@@ -850,5 +909,10 @@ public class AquaResearchDialog extends BaseDialog {
             Draw.color(Pal.accent);
 
         }
+    }
+
+    public float computeRadiusAt(int depth){
+        if(depth <= 0) return 0;
+        return computeRadiusAt(depth - 1) + spacings.get(depth,0);
     }
 }

--- a/main/src/aquarion/dialogs/AquaResearchDialog.java
+++ b/main/src/aquarion/dialogs/AquaResearchDialog.java
@@ -3,6 +3,7 @@ package aquarion.dialogs;
 import aquarion.ModEventHandler;
 import aquarion.content.AquaPlanets;
 import aquarion.ui.ModSettings;
+import aquarion.world.graphics.AquaFill;
 import arc.Core;
 import arc.Events;
 import arc.graphics.Color;
@@ -65,6 +66,10 @@ public class AquaResearchDialog extends BaseDialog {
     public Rect bounds = new Rect();
     public ItemsDisplay itemDisplay;
     public View view;
+
+    //temporary points
+    public static Vec2 v1 = new Vec2(), v2 = new Vec2(), v3 = new Vec2(), v4 = new Vec2(), offset = new Vec2(),
+        v5 = new Vec2();
 
     //The spacings between depth layers. Used to align layers.
     public IntFloatMap spacings = new IntFloatMap();
@@ -821,6 +826,7 @@ public class AquaResearchDialog extends BaseDialog {
             clamp();
             Draw.sort(true);
             float offsetX = panX + width / 2f, offsetY = panY + height / 2f;
+            offset.set(offsetX, offsetY);
             int maxDepth = getMaxDepth(root, 0);
             int totalNodes = nodes.size;
             float spacing = Mathf.clamp(
@@ -867,15 +873,29 @@ public class AquaResearchDialog extends BaseDialog {
                 if(ModSettings.getDebugResearchRendering()) {
                     float nodeRadius = computeRadiusAt(node.depth);
                     float nodeSpacing = spacings.get(node.depth + 1, 0);
+                    float measure = Angles.angleDist(node.leftBorderPos.angle(),node.rightBorderPos.angle());
+
+                    v1.set(node.leftBorderPos).scl(nodeRadius).add(offsetX, offsetY);
+                    v2.set(node.leftBorderPos).scl(nodeSpacing).add(v1);
+
+                    v3.set(node.rightBorderPos).scl(nodeRadius).add(offsetX, offsetY);
+                    v4.set(node.rightBorderPos).scl(nodeSpacing).add(v3);
+
+                    if(!locked(node.node)){
+                        Draw.color(Pal.accent);
+                        AquaFill.arcSlice(
+                                offset,
+                                measure,
+                                v5.set(node.x, node.y).angle(),
+                                nodeRadius,
+                                nodeRadius + nodeSpacing,
+                                Mathf.ceil(Mathf.PI * (nodeRadius + nodeSpacing) / 500)
+                                );
+                    }
 
                     Draw.color(Color.red);
-                    Tmp.v1.set(node.leftBorderPos).scl(nodeRadius).add(offsetX, offsetY);
-                    Tmp.v2.set(node.leftBorderPos).scl(nodeSpacing).add(Tmp.v1);
-                    Lines.line(Tmp.v1.x, Tmp.v1.y, Tmp.v2.x, Tmp.v2.y);
-
-                    Tmp.v1.set(node.rightBorderPos).scl(nodeRadius).add(offsetX, offsetY);
-                    Tmp.v2.set(node.rightBorderPos).scl(nodeSpacing).add(Tmp.v1);
-                    Lines.line(Tmp.v1.x, Tmp.v1.y, Tmp.v2.x, Tmp.v2.y);
+                    Lines.line(v1.x, v1.y, v2.x, v2.y);
+                    Lines.line(v3.x, v3.y, v4.x, v4.y);
                 }
 
                 for (TechTreeNode child : node.children) {

--- a/main/src/aquarion/ui/ModSettings.java
+++ b/main/src/aquarion/ui/ModSettings.java
@@ -17,6 +17,7 @@ public class ModSettings {
             root.checkPref("@settings.betterland", false);
             root.checkPref("@settings.betterfine", false);
             root.checkPref("@settings.richPrescense", true);
+            root.checkPref("@settings.debugResearchRendering", false);
             root.pref(new ButtonPref(
                     Core.bundle.get("settings.resethints"),
                     Icon.trash,
@@ -80,5 +81,9 @@ public class ModSettings {
 
     public static boolean getRichPresence(){
         return Core.settings.getBool("richPrescense", true);
+    }
+
+    public static boolean getDebugResearchRendering(){
+        return Core.settings.getBool("@settings.debugResearchRendering", false);
     }
 }

--- a/main/src/aquarion/world/graphics/AquaFill.java
+++ b/main/src/aquarion/world/graphics/AquaFill.java
@@ -1,0 +1,68 @@
+package aquarion.world.graphics;
+
+import arc.graphics.g2d.Fill;
+import arc.math.Mathf;
+import arc.math.geom.Position;
+import arc.math.geom.Vec2;
+import arc.struct.FloatSeq;
+
+public class AquaFill {
+
+    public static final FloatSeq points = new FloatSeq();
+
+    public static final Vec2 v1 = new Vec2(), v2 = new Vec2(), v3 = new Vec2();
+
+    /**
+     * Draws a slice of a circle with center at x and y, a measure (fraction of the circle), a rotation, and a radius to represent its outer curved edge.
+     * Due to the use of polygon approximations, side is the number of sides to draw for each curve section.
+     * */
+    public static void circleSlice(float x, float y,  float measure, float rotation, float radius, int sides){
+        arcSlice(x, y, measure, rotation, 0, radius, sides);
+    }
+
+    public static void circleSlice(Position center, float measure, float rotation, float radius, int sides){
+        arcSlice(center, measure, rotation, 0, radius, sides);
+    }
+
+    public static void arcSlice(Position center, float measure, float rotation, float innerRadius, float outerRadius, int sides){
+        arcSlice(center.getX(), center.getY(), measure, rotation, innerRadius, outerRadius, sides);
+    }
+
+    /**
+     * Draws an arc with center at x and y, a measure (fraction of the circle), a rotation, and two radii to represent its inner and outer curved edges.
+     * Due to the use of polygon approximations, side is the number of sides to draw for each curve section.
+     * */
+    public static void arcSlice(float x, float y, float measure, float rotation, float innerRadius, float outerRadius, int sides){
+        if (Mathf.zero(outerRadius) || Mathf.zero(measure) || sides == 0) return;
+        points.clear();
+        float fraction = measure / sides;
+        if(Mathf.zero(innerRadius)){
+            points.clear();
+            points.add(x, y);
+            for(int i = 0; i < sides + 1; i++){
+                float angle = rotation - (measure / 2) + fraction * i;
+                v1.trns(angle, outerRadius).add(x, y);
+                points.add(v1.x, v1.y);
+            }
+            Fill.poly(points);
+        } else {
+            v2.trns(rotation - (measure / 2), outerRadius).add(x,y);
+            v3.trns(rotation - (measure / 2), innerRadius).add(x,y);
+
+            for (int i = 1; i < sides + 1; i++) {
+                points.clear();
+                points.add(v2.x, v2.y, v3.x, v3.y);
+                float angle = rotation - (measure / 2) + fraction * i;
+                v1.trns(angle, innerRadius).add(x, y);
+                points.add(v1.x, v1.y);
+                v3.set(v1);
+                v1.trns(angle, outerRadius).add(x, y);
+                points.add(v1.x, v1.y);
+                v2.set(v1);
+                Fill.poly(points);
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
Altered the tech tree to prevent nodes of overlapping, even when adding dense node clusters.
Added a debug renderer for visualization of tech tree node borders
Added a setting to enable the debug renderer
Added a rendering function for drawing slices and arc sections of circles.
Added arc section debug drawing for unlocked regions in the tech tree.